### PR TITLE
Add Jenkins CI to the repo with code refactoring

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -64,31 +64,70 @@ spec:
     }
   }
 
+// required by Terraform
+environment {
+   GOOGLE_APPLICATION_CREDENTIALS    = '/home/jenkins/dev/jenkins-deploy-dev-infra.json'
+}
 
-  stages {
+stages {
+
     stage('Setup access') {
       steps {
         container('k8s-node') {
           script {
-                env.KEYFILE = "/home/jenkins/dev/jenkins-deploy-dev-infra.json"
+                env.PROJECT_ID = "${PROJECT_ID}"
+                env.REGION = "${REGION}"
+                env.ZONE = "${ZONE}"
+                env.KEYFILE = GOOGLE_APPLICATION_CREDENTIALS
             }
           // Setup gcloud service account access
           sh "gcloud auth activate-service-account --key-file=${env.KEYFILE}"
+          sh "gcloud config set core/project ${env.PROJECT_ID}"
+          sh "gcloud config set compute/region ${env.REGION}"
+          sh "gcloud config set compute/zone ${env.ZONE}"
          }
         }
     }
-
-    stage('makeall') {
+    // linter testing
+    stage('linter') {
       steps {
         container('k8s-node') {
           // Checkout code from repository
           checkout scm
-
           sh "make all"
         }
       }
     }
-  }
+   // create infrastructure
+    stage('create') {
+      steps {
+        container('k8s-node') {
+          sh "make create"
+        }
+      }
+    }
+    // validate infrastructure
+    stage('validate') {
+      steps {
+        container('k8s-node') {
+          script {
+            for (int i = 0; i < 3; i++) {
+               sh "make validate"
+            }
+          }
+        }
+      }
+    }
+    // delete infrastructure
+    stage('delete') {
+      steps {
+        container('k8s-node') {
+          sh "make delete"
+        }
+      }
+    }
+
+}
 
   post {
     always {

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,20 @@
 # limitations under the License.
 # Make will use bash instead of sh
 SHELL := /usr/bin/env bash
+ROOT := ${CURDIR}
+
+# create/delete/validate is for CICD
+.PHONY: create
+create:
+	$(ROOT)/create.sh
+.PHONY: delete
+delete:
+	$(ROOT)/delete.sh
+
+.PHONY: validate
+validate:
+	${ROOT}/validate.sh
+
 # All is the first target in the file so it will get picked up when you just run 'make' on its own
 all: check_shell check_shebangs check_python check_golang check_terraform check_docker check_base_files check_headers check_trailing_whitespace
 
@@ -48,9 +62,6 @@ tf-destroy:
 	# Downloads the terraform providers and applies the configuration
 	cd terraform && terraform destroy
 
-.PHONY: validate
-validate:
-	./setup_manifests.sh && ./validate.sh
 
 .PHONY: clean-up
 clean-up:

--- a/common.sh
+++ b/common.sh
@@ -1,0 +1,86 @@
+#!/bin/bash -e
+
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# "---------------------------------------------------------"
+# "-                                                       -"
+# "-  Common commands for all scripts                      -"
+# "-                                                       -"
+# "---------------------------------------------------------"
+
+# git is required for this tutorial
+command -v git >/dev/null 2>&1 || { \
+ echo >&2 "I require git but it's not installed.  Aborting."; exit 1; }
+
+# glcoud is required for this tutorial
+command -v gcloud >/dev/null 2>&1 || { \
+ echo >&2 "I require gcloud but it's not installed.  Aborting."; exit 1; }
+
+# bastion set up
+BASTION_INSTANCE_NAME=gke-demo-bastion
+# set to jenkins if there is no $USER
+USER=$(whoami)
+[[ "${USER}" == "root" ]] && export USER=jenkins
+echo "user is: $USER"
+
+
+# validate deployment status via bastion server
+function validate_deployment_bastion() {
+    deployment=$1
+    ROLLOUT=$(gcloud compute ssh "${USER}"@"${BASTION_INSTANCE_NAME}" --command "kubectl rollout status deploy/${deployment}")
+    MESSAGE="deployment \"${deployment}\" successfully rolled out"
+    # Test the ROLLOUT variable to see if the grep has returned the expected value.
+    # Depending on the test print success or failure messages.
+    if [[ $ROLLOUT = *"$MESSAGE"* ]]; then
+    echo "Validation Passed: the deployment ${deployment} has been deployed"
+    else
+    echo "Validation Failed: the deployment ${deployment} has not been deployed"
+    exit 1
+    fi
+}
+
+
+# gcloud config holds values related to your environment. If you already
+# defined a default region we will retrieve it and use it
+REGION="$(gcloud config get-value compute/region)"
+if [[ -z "${REGION}" ]]; then
+    echo "https://cloud.google.com/compute/docs/regions-zones/changing-default-zone-region" 1>&2
+    echo "gcloud cli must be configured with a default region." 1>&2
+    echo "run 'gcloud config set compute/region REGION'." 1>&2
+    echo "replace 'REGION' with the region name like us-west1." 1>&2
+    exit 1;
+fi
+
+# gcloud config holds values related to your environment. If you already
+# defined a default zone we will retrieve it and use it
+ZONE="$(gcloud config get-value compute/zone)"
+if [[ -z "${ZONE}" ]]; then
+    echo "https://cloud.google.com/compute/docs/regions-zones/changing-default-zone-region" 1>&2
+    echo "gcloud cli must be configured with a default zone." 1>&2
+    echo "run 'gcloud config set compute/zone ZONE'." 1>&2
+    echo "replace 'ZONE' with the zone name like us-west1-a." 1>&2
+    exit 1;
+fi
+
+# gcloud config holds values related to your environment. If you already
+# defined a default project we will retrieve it and use it
+PROJECT="$(gcloud config get-value core/project)"
+if [[ -z "${PROJECT}" ]]; then
+    echo "gcloud cli must be configured with a default project." 1>&2
+    echo "run 'gcloud config set core/project PROJECT'." 1>&2
+    echo "replace 'PROJECT' with the project name." 1>&2
+    exit 1;
+fi
+

--- a/delete.sh
+++ b/delete.sh
@@ -1,0 +1,36 @@
+#!/bin/bash -e
+
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# "---------------------------------------------------------"
+# "-                                                       -"
+# "-  Delete uninstalls Cassandra and deletes              -"
+# "-  the GKE cluster                                      -"
+# "-                                                       -"
+# "---------------------------------------------------------"
+
+# Do not set errexit as it makes partial deletes impossible
+set -o nounset
+set -o pipefail
+
+ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+# shellcheck disable=SC1090
+source "$ROOT"/common.sh
+
+# Tear down hello-app
+gcloud compute ssh "${USER}"@"${BASTION_INSTANCE_NAME}" --command "kubectl delete -f manifests/hello-app/"
+# Terraform destroy
+cd terraform && terraform destroy -auto-approve
+

--- a/generate-tfvars.sh
+++ b/generate-tfvars.sh
@@ -24,50 +24,12 @@
 # Stop immediately if something goes wrong
 set -euo pipefail
 
-# This script should be run from directory that contains the terraform directory.
 # The purpose is to populate defaults for subsequent terraform commands.
+ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+# shellcheck disable=SC1090
+source "$ROOT"/common.sh
 
-# git is required for this tutorial
-command -v git >/dev/null 2>&1 || { \
- echo >&2 "I require git but it's not installed.  Aborting."; exit 1; }
-
-# glcoud is required for this tutorial
-command -v gcloud >/dev/null 2>&1 || { \
- echo >&2 "I require gcloud but it's not installed.  Aborting."; exit 1; }
-
-
-# gcloud config holds values related to your environment. If you already
-# defined a default region we will retrieve it and use it
-REGION="$(gcloud config get-value compute/region)"
-if [[ -z "${REGION}" ]]; then
-    echo "https://cloud.google.com/compute/docs/regions-zones/changing-default-zone-region" 1>&2
-    echo "gcloud cli must be configured with a default region." 1>&2
-    echo "run 'gcloud config set compute/region REGION'." 1>&2
-    echo "replace 'REGION' with the region name like us-west1." 1>&2
-    exit 1;
-fi
-
-# gcloud config holds values related to your environment. If you already
-# defined a default zone we will retrieve it and use it
-ZONE="$(gcloud config get-value compute/zone)"
-if [[ -z "${ZONE}" ]]; then
-    echo "https://cloud.google.com/compute/docs/regions-zones/changing-default-zone-region" 1>&2
-    echo "gcloud cli must be configured with a default zone." 1>&2
-    echo "run 'gcloud config set compute/zone ZONE'." 1>&2
-    echo "replace 'ZONE' with the zone name like us-west1-a." 1>&2
-    exit 1;
-fi
-
-# gcloud config holds values related to your environment. If you already
-# defined a default project we will retrieve it and use it
-PROJECT="$(gcloud config get-value core/project)"
-if [[ -z "${PROJECT}" ]]; then
-    echo "gcloud cli must be configured with a default project." 1>&2
-    echo "run 'gcloud config set core/project PROJECT'." 1>&2
-    echo "replace 'PROJECT' with the project name." 1>&2
-    exit 1;
-fi
-
+# This script should be run from directory that contains the terraform directory.
 
 # Use git to find the top-level directory and confirm
 # by looking for the 'terraform' directory
@@ -101,6 +63,7 @@ else
 project="${PROJECT}"
 region="${REGION}"
 zone="${ZONE}"
+ssh_user_bastion="${USER}"
 EOF
 fi
 )

--- a/setup_manifests.sh
+++ b/setup_manifests.sh
@@ -16,11 +16,15 @@
 # bash "strict-mode", fail immediately if there is a problem
 set -euo pipefail
 
+ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+# shellcheck disable=SC1090
+source "$ROOT"/common.sh
+
 # A helper method to make calls to the gke cluster through the bastion.
 call_bastion() {
   local command=$1; shift;
   # shellcheck disable=SC2005
-  echo "$(gcloud compute ssh gke-demo-bastion --command "${command}")"
+  echo "$(gcloud compute ssh "${USER}"@gke-demo-bastion --command "${command}")"
 }
 MESSAGE="successfully rolled out"
 

--- a/terraform/bastion.tf
+++ b/terraform/bastion.tf
@@ -76,10 +76,11 @@ resource "google_compute_instance" "gke-bastion" {
 
   // Copy the manifests to the bastion
   provisioner "local-exec" {
+    interpreter = ["/bin/bash", "-c"]
     command = <<EOF
         READY=""
         for i in $(seq 1 18); do
-          if gcloud compute ssh ${var.bastion_hostname} --command uptime; then
+          if gcloud compute ssh ${var.ssh_user_bastion}@${var.bastion_hostname} --command uptime; then
             READY="yes"
             break;
           fi
@@ -93,7 +94,7 @@ resource "google_compute_instance" "gke-bastion" {
           exit 1
         fi
 
-        gcloud compute --project ${var.project} scp --zone ${var.zone} --recurse ../manifests ${var.bastion_hostname}:
+        gcloud compute  --project ${var.project} scp --zone ${var.zone} --recurse ../manifests ${var.ssh_user_bastion}@${var.bastion_hostname}:
 EOF
   }
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -118,3 +118,9 @@ variable "vpc_name" {
   type        = "string"
   default     = "kube-net"
 }
+
+variable "ssh_user_bastion" {
+  description = "ssh user for bastion server"
+  type        = "string"
+  default     = "jenkins"
+}

--- a/validate.sh
+++ b/validate.sh
@@ -15,6 +15,11 @@
 
 # bash "strict-mode", fail immediately if there is a problem
 set -euo pipefail
+
+ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+# shellcheck disable=SC1090
+source "$ROOT"/common.sh
+
 HELLO_WORLD='Hello, world!'
 TIMED_OUT='wget: download timed out'
 
@@ -22,7 +27,7 @@ TIMED_OUT='wget: download timed out'
 call_bastion() {
   local command=$1; shift;
   # shellcheck disable=SC2005
-  echo "$(gcloud compute ssh gke-demo-bastion --command "${command}")"
+  echo "$(gcloud compute ssh "$USER"@gke-demo-bastion --command "${command}")"
 }
 
 # We expect to see "Hello, world!" in the logs with the app=hello label.


### PR DESCRIPTION
1. Refactor for both CICD and laptop manual demo scenario. 
Key difference between CICD and manual demo:
- gcloud zone, project
- Terraform service account set up: GOOGLE_APPLICATION_CREDENTIALS  (in Jenkinsfile)
- gcloud compute ssh with explicit user both in shell script and Terraform local-exec provisioner. 
using /sh.
2. Refactor for software engineering
- script refactor: use common.sh to keep common variables, functions. 
- Follow makefile wrapper name convention: create/delete/validate as Makefile target, then each uses a script. 
- k8s manifest: create it as part of create.sh. 
- Validation: based on the k8s manifest deployment on hello-app
- Found a bug in local-exec provisioner, that needs /bin/bash due to "[[" condition operator instead of 

3. Merge and resolved the conflict with upstream master branch. 
4. Tested with Jenkins on https://ci.gflocks.com/job/pydevops-gke-network-policy-demo/12/console as a successful run. 
