### PR TITLE
Bug fixes on validation and delete

### DIFF
--- a/delete.sh
+++ b/delete.sh
@@ -31,6 +31,10 @@ source "$ROOT"/common.sh
 
 # Tear down hello-app
 gcloud compute ssh "${USER}"@"${BASTION_INSTANCE_NAME}" --command "kubectl delete -f manifests/hello-app/"
+
+# remove metadata for bastion (SSH keys)
+gcloud compute instances remove-metadata --all "${BASTION_INSTANCE_NAME}" --project "${PROJECT}" --zone "${ZONE}"
+
 # Terraform destroy
 cd terraform && terraform destroy -auto-approve
 

--- a/validate.sh
+++ b/validate.sh
@@ -45,8 +45,8 @@ echo "step 2 of the validation passed."
 # Apply the network policy.
 call_bastion "kubectl apply -f ./manifests/network-policy.yaml" &> /dev/null
 
-# Sleep for 3s while more logs come in.
-sleep 3
+# Sleep for 10s while more logs come in.
+sleep 10
 
 # Now we expect to see a 'timed out' message because the network policy
 # prevents the communication.


### PR DESCRIPTION
1. add more sleep time for validation step #3 to avoid a race condition
2. clean up SSH keys for bastion host

The test finished successfully: https://ci.gflocks.com/job/pydevops-gke-network-policy-demo/16/console 