### PR TITLE
Updated Readme, fixed terraform code for private cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,7 +360,7 @@ Hostname: hello-server-6c6fd59cc9-7fvgp
 Log out of the bastion host and run the following to destroy the environment:
 
 ```console
-make tf-destroy
+make teardown
 
 ...snip...
 google_compute_subnetwork.cluster-subnet: Still destroying... (ID: us-east1/kube-net-subnet, 20s elapsed)

--- a/manifests/network-policy-namespaced.yaml
+++ b/manifests/network-policy-namespaced.yaml
@@ -15,7 +15,7 @@
 # Defines a new namespace used to demonstrate whitelisting an entire namespace
 # See https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
 kind: Namespace
-apiVersion: core/v1
+apiVersion: v1
 metadata:
   name: hello-apps
   labels:
@@ -55,4 +55,3 @@ spec:
     - namespaceSelector:
         matchLabels:
           team: hello
-

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -67,8 +67,12 @@ resource "google_container_cluster" "primary" {
     cluster_secondary_range_name = "secondary-range"
   }
 
-  master_ipv4_cidr_block = "${var.master_cidr_block}"
-  private_cluster        = true
+  // In a private cluster, the master has two IP addresses, one public and one
+   // private. Nodes communicate to the master through this private IP address.
+   private_cluster_config {
+     enable_private_nodes   = true
+     master_ipv4_cidr_block = "10.0.90.0/28"
+   }
 
   // (Required for private cluster, optional otherwise) network (cidr) from which cluster is accessible
   master_authorized_networks_config {


### PR DESCRIPTION
Made the below updates:
1. Readme file: replaced tf-destroy to teardown command.
2. manifests/network-policy-namespaced.yaml: changed apiVersion from core/v1 to v1.
3. terraform/main.tf: Replaced deprecated field private_clusters to newer version i.e private_cluster_config block.