### PR TITLE
upgraded google provider to latest version

### DIFF
--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -18,6 +18,6 @@ limitations under the License.
 provider "google" {
   project = var.project
   region  = var.region
-  version = "~> 2.10.0"
+  version = "~> 2.17.0"
 }
 


### PR DESCRIPTION
To avoid timeouts during cluster creation I had to upgrade google provider version to latest one. 