### PR TITLE
Fix deprecation notice for "zone"

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -21,7 +21,6 @@ version of the Cloud Console form you would use to create a Kubernetes Engine cl
 
 # Gets the current version of Kubernetes engine
 data "google_container_engine_versions" "gke_version" {
-  zone = var.zone
 }
 
 // https://www.terraform.io/docs/providers/google/d/google_container_cluster.html

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -21,6 +21,7 @@ version of the Cloud Console form you would use to create a Kubernetes Engine cl
 
 # Gets the current version of Kubernetes engine
 data "google_container_engine_versions" "gke_version" {
+    location   = var.zone
 }
 
 // https://www.terraform.io/docs/providers/google/d/google_container_cluster.html

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -21,7 +21,7 @@ version of the Cloud Console form you would use to create a Kubernetes Engine cl
 
 # Gets the current version of Kubernetes engine
 data "google_container_engine_versions" "gke_version" {
-    location   = var.zone
+  location   = var.zone
 }
 
 // https://www.terraform.io/docs/providers/google/d/google_container_cluster.html


### PR DESCRIPTION
This PR fixes the deprecation notice for the "google_container_engine_versions" data resource in main.tf