### PR TITLE
Fix OOM on bastion VM

### DIFF
--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -43,7 +43,7 @@ Defaults will be used for these, if not overridden at runtime.
 variable "bastion_machine_type" {
   description = "The instance size to use for your bastion instance."
   type        = string
-  default     = "f1-micro"
+  default     = "g1-small"
 }
 
 variable "bastion_hostname" {


### PR DESCRIPTION
In the process of https://www.qwiklabs.com/focuses/5572 got Out Of Memory error from kubectl after any command, which could be managed only with VM restart.

This fix should fix kubectl memory requirement.