### PR TITLE
update apiVersion of Deployment from extensions/v1beta1 to apps/v1

### DIFF
--- a/README-QWIKLABS.md
+++ b/README-QWIKLABS.md
@@ -153,7 +153,7 @@ kubectl apply -f ./manifests/hello-app/
 deployment.apps/hello-client-allowed created
 deployment.apps/hello-client-blocked created
 service/hello-server created
-deployment.extensions/hello-server created
+deployment.apps/hello-server created
 ```
 
 Use `kubectl get pods`` to verify all three pods have been successfully deployed.

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ kubectl apply -f ./manifests/hello-app/
 deployment.apps/hello-client-allowed created
 deployment.apps/hello-client-blocked created
 service/hello-server created
-deployment.extensions/hello-server created
+deployment.apps/hello-server created
 ```
 
 Use `kubectl get pods`` to verify all three pods have been successfully deployed.

--- a/manifests/hello-app/hello-server.yaml
+++ b/manifests/hello-app/hello-server.yaml
@@ -44,7 +44,7 @@ spec:
 ---
 
 # Deploys a pod to service hello-server requests
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   # Label and name the deployment


### PR DESCRIPTION
Deployment in extensions/v1beta1 is deprecated in Kubernetes v1.16.
https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/

Currently, GKE is using v1.14 or v1.15, and so these manifests can be applied.
However, a few months later, GKE will use v1.16, and then the manifests cannot be applied.