### PR TITLE
Invalid master authorized networks issue fixed

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -70,6 +70,7 @@ resource "google_container_cluster" "primary" {
   private_cluster_config {
     enable_private_nodes   = true
     master_ipv4_cidr_block = "10.0.90.0/28"
+    enable_private_endpoint = false
   }
 
   // (Required for private cluster, optional otherwise) network (cidr) from which cluster is accessible


### PR DESCRIPTION
When I tried this lab it will give me error "Invalid master authorized networks: network "<cidr>" is not a reserved network, which is required for private endpoints." and I fixed this issue on lab by enable_private_endpoint = false