### PR TITLE
Update Debian version on bastion VM

### DIFF
--- a/terraform/bastion.tf
+++ b/terraform/bastion.tf
@@ -52,7 +52,7 @@ resource "google_compute_instance" "gke-bastion" {
   // Specify the Operating System Family and version.
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-9"
+      image = "debian-cloud/debian-10"
     }
   }
 


### PR DESCRIPTION
Terraform gives error "Could not find image or family debian-cloud/debian-9". It seems that the image version needs to be updated to version 10.