### PR TITLE
Updates for warnings and deprecations

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -70,6 +70,7 @@ resource "google_container_cluster" "primary" {
   private_cluster_config {
     enable_private_nodes   = true
     master_ipv4_cidr_block = "10.0.90.0/28"
+    enable_private_endpoint = false      
   }
 
   // (Required for private cluster, optional otherwise) network (cidr) from which cluster is accessible

--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -18,6 +18,5 @@ limitations under the License.
 provider "google" {
   project = var.project
   region  = var.region
-  version = "~> 2.17.0"
 }
 


### PR DESCRIPTION
fix version constraint in `provider` block and add `enable_private_endpoint` in the `google_container_cluster` `private_cluster_config` block.